### PR TITLE
Smile 720 queue alarms

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -272,7 +272,7 @@ Resources:
             Value: !GetAtt DynamodbStreamDLQ.QueueName
       Statistic: Sum
       EvaluationPeriods: 1
-      Period: 300 #5 minutes
+      Period: 600 #10 minutes
       Threshold: 0
       ComparisonOperator: GreaterThanThreshold
       AlarmActions:
@@ -289,7 +289,7 @@ Resources:
       AlarmName: !Sub "AlmaUpdateDLQAlarm-${AWS::StackName}"
       AlarmDescription: 'Messages in the dead letter queue exceeds defined threshold.'
       Namespace: AWS/SQS
-      MetricName: NumberOfMessagesReceived
+      MetricName: ApproximateNumberOfMessagesVisible
       Dimensions:
         -   Name: QueueName
             Value: !GetAtt AlmaUpdateDLQ.QueueName
@@ -312,7 +312,7 @@ Resources:
       AlarmName: !Sub "AlmaUpdateExhaustedAlarm-${AWS::StackName}"
       AlarmDescription: 'There are messages in the queue.'
       Namespace: AWS/SQS
-      MetricName: NumberOfMessagesReceived
+      MetricName: ApproximateNumberOfMessagesVisible
       Dimensions:
         -   Name: QueueName
             Value: !GetAtt AlmaUpdateExhausted.QueueName

--- a/template.yaml
+++ b/template.yaml
@@ -202,7 +202,6 @@ Resources:
             QueueName:
               !GetAtt AlmaUpdateExhausted.QueueName
 
-
   AlmaErrorScheduler:
     Type: AWS::Serverless::Function
     Properties:
@@ -260,3 +259,96 @@ Resources:
         - !Ref AlmaDLQAlarmNotification
       OKActions:
         - !Ref AlmaDLQAlarmNotification
+
+  DynamodbStreamDLQAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "DynamodbStreamDLQAlarm-${AWS::StackName}"
+      AlarmDescription: 'There are messages in the dead letter queue.'
+      Namespace: AWS/SQS
+      MetricName: NumberOfMessagesReceived
+      Dimensions:
+        -   Name: QueueName
+            Value: !GetAtt DynamodbStreamDLQ.QueueName
+      Statistic: Sum
+      EvaluationPeriods: 1
+      Period: 300 #5 minutes
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions:
+        - !Ref DynamodbStreamDLQAlarmNotification
+
+  DynamodbStreamDLQAlarmNotification:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: !Sub "DynamodbStreamDLQAlarmNotification-${AWS::StackName}"
+
+  AlmaUpdateDLQAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "AlmaUpdateDLQAlarm-${AWS::StackName}"
+      AlarmDescription: 'Messages in the dead letter queue exceeds defined threshold.'
+      Namespace: AWS/SQS
+      MetricName: NumberOfMessagesReceived
+      Dimensions:
+        -   Name: QueueName
+            Value: !GetAtt AlmaUpdateDLQ.QueueName
+      Statistic: Sum
+      EvaluationPeriods: 1
+      Period: 86400 #1 day
+      Threshold: 200
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions:
+        - !Ref AlmaUpdateDLQAlarmAlarmNotification
+
+  AlmaUpdateDLQAlarmNotification:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: !Sub "AlmaUpdateDLQAlarmNotification-${AWS::StackName}"
+
+  AlmaUpdateExhaustedAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "AlmaUpdateExhaustedAlarm-${AWS::StackName}"
+      AlarmDescription: 'There are messages in the queue.'
+      Namespace: AWS/SQS
+      MetricName: NumberOfMessagesReceived
+      Dimensions:
+        -   Name: QueueName
+            Value: !GetAtt AlmaUpdateExhausted.QueueName
+      Statistic: Sum
+      EvaluationPeriods: 1
+      Period: 86400 #1 day
+      Threshold: 1
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions:
+        - !Ref AlmaUpdateExhaustedAlarmNotification
+
+  AlmaUpdateExhaustedAlarmNotification:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: !Sub "AlmaUpdateExhaustedAlarmNotification-${AWS::StackName}"
+
+  UpdateAlmaDescriptionFunctionAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "UpdateAlmaDescriptionFunctionAlarm-${AWS::StackName}"
+      AlarmDescription: 'Error occurred in function.'
+      Namespace: AWS/Lambda
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref UpdateAlmaDescriptionFunction
+      MetricName: Errors
+      Statistic: Sum
+      Period: 300 #5 minutes
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref UpdateAlmaDescriptionFunctionAlarmNotification
+
+  UpdateAlmaDescriptionFunctionAlarmNotification:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: !Sub "UpdateAlmaDescriptionFunctionAlarmNotification-${AWS::StackName}"


### PR DESCRIPTION
Lagt inn alarmer og tilhørende sns-topics i template.

Legge til og endre epost-varsling etc. på sns-topic'ene gjøres kjapt manuelt inne i AWS.

Justering av grenseverdiene på alarmer må vi finne ut over tid, men disse kan også kjapt endres inne i AWS frem til vi finner gode verdier, også kan vi deretter legge disse inn i template.

Jeg har ikke klusset med stacken i sandbox for å teste template, men tror det er kjappest å rette evt. små feil rett i develop dersom pipeline feiler.

